### PR TITLE
Logs lacosmicx installation errors

### DIFF
--- a/kcwidrp/primitives/RemoveCosmicRays.py
+++ b/kcwidrp/primitives/RemoveCosmicRays.py
@@ -3,12 +3,6 @@ from kcwidrp.primitives.kcwi_file_primitives import kcwi_fits_writer
 
 import numpy as np
 
-try:
-    import _lacosmicx
-except ImportError:
-    print("Please install lacosmicx from github.com/cmccully/lacosmicx.")
-    quit()
-
 
 class RemoveCosmicRays(BasePrimitive):
     """Remove cosmic rays and generate a flag image recording their location"""
@@ -16,6 +10,12 @@ class RemoveCosmicRays(BasePrimitive):
     def __init__(self, action, context):
         BasePrimitive.__init__(self, action, context)
         self.logger = context.pipeline_logger
+
+        try:
+            import _lacosmicx
+        except ImportError:
+            self.logger.error("Please install lacosmicx from github.com/cmccully/lacosmicx.")
+            quit()
 
     def _perform(self):
         # TODO: implement parameter options from kcwi_stage1.pro


### PR DESCRIPTION
Moved the import block for lacosmicx in RemoveCosmicRays.py to the __init__ function, allowing logging of any excepted errors. Previously the error was only printed to terminal, preventing logs from storing import problems