### PR TITLE
Adjust framework config to allow all fits files

### DIFF
--- a/kcwidrp/configs/framework.cfg
+++ b/kcwidrp/configs/framework.cfg
@@ -49,7 +49,7 @@ primitive_path = "kcwidrp.primitives", ""
 #
 # File type for Data_set
 #
-file_type = "kb*.fits"
+file_type = "*.fits"
 
 #
 # Final result output directory.


### PR DESCRIPTION
This allows the user to input any fits files they like, which should allow the user to use both KOA and OFNAME styled files