### PR TITLE
Bring back TWIFLAT and DOMEFLAT to the reduced types. Fixes #69

### DIFF
--- a/kcwidrp/scripts/reduce_kcwi.py
+++ b/kcwidrp/scripts/reduce_kcwi.py
@@ -238,7 +238,7 @@ def main():
         data_set.data_table.drop(ccdclear_frames, inplace=True)
 
         # processing
-        imtypes = ['BIAS', 'CONTBARS', 'ARCLAMP', 'FLATLAMP', 'OBJECT']
+        imtypes = ['BIAS', 'CONTBARS', 'ARCLAMP', 'FLATLAMP', 'DOMEFLAT', 'TWIFLAT', 'OBJECT']
 
         for imtype in imtypes:
             subset = data_set.data_table[


### PR DESCRIPTION
this is really a simple change to reduce_kcwi.py
I tested it on two datasets and it works correctly
