### PR TITLE
Resolve cardname to long warnings

### DIFF
--- a/kcwidrp/primitives/MakeMasterBias.py
+++ b/kcwidrp/primitives/MakeMasterBias.py
@@ -10,6 +10,7 @@ import ccdproc
 import numpy as np
 from scipy.stats import sigmaclip
 import time
+import os
 
 
 class MakeMasterBias(BaseImg):
@@ -69,7 +70,8 @@ class MakeMasterBias(BaseImg):
                                     'number of images stacked')
         stacked.header['STCKMETH'] = (method, 'method used for stacking')
         for ii, fname in enumerate(stackf):
-            stacked.header['STACKF%d' % (ii + 1)] = (fname, "stack input file")
+            fname_base = os.path.basename(fname)
+            stacked.header['STACKF%d' % (ii + 1)] = (fname_base, "stack input file")
 
         # for readnoise stats use 2nd and 3rd bias
         diff = stack[1].data.astype(np.float32) - \

--- a/kcwidrp/primitives/MakeMasterSky.py
+++ b/kcwidrp/primitives/MakeMasterSky.py
@@ -281,7 +281,8 @@ class MakeMasterSky(BaseImg):
         self.action.args.ccddata.data = sky
 
         # get master sky output name
-        ofn = self.action.args.name
+        ofn_full = self.action.args.name
+        ofn = os.path.basename(ofn_full)
         msname = strip_fname(ofn) + '_' + suffix + '.fits'
 
         log_string = MakeMasterSky.__module__


### PR DESCRIPTION
Full file paths were being saved to fits headers where only filenames were needed. resolves #86 