### PR TITLE
Bad pixel masking

### DIFF
--- a/kcwidrp/primitives/StackFlats.py
+++ b/kcwidrp/primitives/StackFlats.py
@@ -75,13 +75,16 @@ class StackFlats(BaseImg):
         stacked = ccdproc.combine(stack, method=method, sigma_clip=True,
                                   sigma_clip_low_thresh=None,
                                   sigma_clip_high_thresh=2.0)
-        name = strip_fname(combine_list[-1]) + '_intd.fits'
-        path = os.path.join(self.config.instrument.cwd,
-                                  self.config.instrument.output_directory,
-                                name)
-        last_flat = kcwi_fits_reader(path)[0]
 
+        # Get the BPM out of one of the flats (bpm is the same for all flats)
+        # and add it to the stacked flat as the stack's mask
+        last_flat_name = strip_fname(combine_list[-1]) + '_intd.fits'
+        last_flat_path = os.path.join(self.config.instrument.cwd,
+                                  self.config.instrument.output_directory,
+                                last_flat_name)
+        last_flat = kcwi_fits_reader(last_flat_path)[0]
         stacked.mask = last_flat.mask
+        
         stacked.header['IMTYPE'] = self.action.args.stack_type
         stacked.header['NSTACK'] = (len(combine_list),
                                     'number of images stacked')

--- a/kcwidrp/primitives/StackFlats.py
+++ b/kcwidrp/primitives/StackFlats.py
@@ -66,8 +66,6 @@ class StackFlats(BaseImg):
                                 stackf[-1])
             # using [0] gets just the image data
             f = kcwi_fits_reader(flatfn)[0]
-            # Save a mask to add to the stack later
-            mask = np.copy(f.mask)
             # Set mask to None to prevent ccdproc.combine from masking
             f.mask = None
             stack.append(f)
@@ -76,7 +74,7 @@ class StackFlats(BaseImg):
                                   sigma_clip_low_thresh=None,
                                   sigma_clip_high_thresh=2.0)
 
-        # Get the BPM out of one of the flats (bpm is the same for all flats)
+        # Get the BPM out of one of the flats (bpm is the same for all)
         # and add it to the stacked flat as the stack's mask
         last_flat_name = strip_fname(combine_list[-1]) + '_intd.fits'
         last_flat_path = os.path.join(self.config.instrument.cwd,

--- a/kcwidrp/primitives/StackFlats.py
+++ b/kcwidrp/primitives/StackFlats.py
@@ -66,15 +66,16 @@ class StackFlats(BaseImg):
                                 stackf[-1])
             # using [0] gets just the image data
             f = kcwi_fits_reader(flatfn)[0]
-            # Set mask to None to prevent ccdproc.combine from masking
+            # Save a mask to add to the stack later
             mask = np.copy(f.mask)
+            # Set mask to None to prevent ccdproc.combine from masking
             f.mask = None
             stack.append(f)
 
         stacked = ccdproc.combine(stack, method=method, sigma_clip=True,
                                   sigma_clip_low_thresh=None,
                                   sigma_clip_high_thresh=2.0)
-        # stacked.mask = stacked.mask & mask
+        stacked.mask = mask
         stacked.header['IMTYPE'] = self.action.args.stack_type
         stacked.header['NSTACK'] = (len(combine_list),
                                     'number of images stacked')

--- a/kcwidrp/primitives/StackFlats.py
+++ b/kcwidrp/primitives/StackFlats.py
@@ -75,7 +75,13 @@ class StackFlats(BaseImg):
         stacked = ccdproc.combine(stack, method=method, sigma_clip=True,
                                   sigma_clip_low_thresh=None,
                                   sigma_clip_high_thresh=2.0)
-        stacked.mask = mask
+        name = strip_fname(combine_list[-1]) + '_intd.fits'
+        path = os.path.join(self.config.instrument.cwd,
+                                  self.config.instrument.output_directory,
+                                name)
+        last_flat = kcwi_fits_reader(path)[0]
+
+        stacked.mask = last_flat.mask
         stacked.header['IMTYPE'] = self.action.args.stack_type
         stacked.header['NSTACK'] = (len(combine_list),
                                     'number of images stacked')

--- a/kcwidrp/primitives/StackFlats.py
+++ b/kcwidrp/primitives/StackFlats.py
@@ -74,7 +74,7 @@ class StackFlats(BaseImg):
         stacked = ccdproc.combine(stack, method=method, sigma_clip=True,
                                   sigma_clip_low_thresh=None,
                                   sigma_clip_high_thresh=2.0)
-        stacked.mask = stacked.mask & mask
+        # stacked.mask = stacked.mask & mask
         stacked.header['IMTYPE'] = self.action.args.stack_type
         stacked.header['NSTACK'] = (len(combine_list),
                                     'number of images stacked')


### PR DESCRIPTION
Fixes #82 by preventing ccdproc from seeing the bad pixel masks in `StackFlats.py`. Copies the bpm from one of the input flats to the stacked flat's mask extension so it is can be used later in the pipeline