### PR TITLE
Rti group mode update

### DIFF
--- a/kcwidrp/configs/rti.cfg
+++ b/kcwidrp/configs/rti.cfg
@@ -1,7 +1,7 @@
 [RTI_LEVEL1]
 
 # Keck Deployment Parameters
-rti_url = https://www2.keck.hawaii.edu/koa/koa_team/rti_status.php
+rti_url = ''
 rti_attempts = 3 # How many times should the pipeline retry connecting to RTI
 rti_retry_time = 5 # How many seconds to wait before trying connection again
 
@@ -34,7 +34,7 @@ extra_process = bokeh,FirefoxApp,geckodriver
 
 [RTI_LEVEL2]
 # Keck Deployment Parameters
-rti_url = https://www2.keck.hawaii.edu/koa/koa_team/rti_status.php
+rti_url = ''
 rti_attempts = 3 # How many times should the pipeline retry connecting to RTI
 rti_retry_time = 5 # How many seconds to wait before trying connection again
 

--- a/kcwidrp/configs/rti.cfg
+++ b/kcwidrp/configs/rti.cfg
@@ -34,14 +34,13 @@ extra_process = bokeh,FirefoxApp,geckodriver
 
 [RTI_LEVEL2]
 # Keck Deployment Parameters
-;rti_url = https://www2.keck.hawaii.edu/koa/koa_team/rti_status.php
-rti_url = http://vm-koarti.keck.hawaii.edu:55556/ingest_api
+rti_url = https://www2.keck.hawaii.edu/koa/koa_team/rti_status.php
 rti_attempts = 3 # How many times should the pipeline retry connecting to RTI
 rti_retry_time = 5 # How many seconds to wait before trying connection again
 
 # Credentials for rti url access. Needs to be filled in on deployment
-rti_user = 'koa'
-rti_pass = 'plate2'
+rti_user = ''
+rti_pass = ''
 
 rti_ingesttype = 'lev2'
 rti_reingest = False

--- a/kcwidrp/configs/rti.cfg
+++ b/kcwidrp/configs/rti.cfg
@@ -6,8 +6,8 @@ rti_attempts = 3 # How many times should the pipeline retry connecting to RTI
 rti_retry_time = 5 # How many seconds to wait before trying connection again
 
 # Credentials for rti url access. Needs to be filled in on deployment
-rti_user = 'koa'
-rti_pass = 'plate2'
+rti_user = ''
+rti_pass = ''
 
 # RTI API parameters
 rti_ingesttype = 'lev1'

--- a/kcwidrp/configs/rti.cfg
+++ b/kcwidrp/configs/rti.cfg
@@ -1,14 +1,65 @@
-[RTI]
+[RTI_LEVEL1]
 
 # Keck Deployment Parameters
-rti_url = http://localhost:5000
+rti_url = https://www2.keck.hawaii.edu/koa/koa_team/rti_status.php
 rti_attempts = 3 # How many times should the pipeline retry connecting to RTI
 rti_retry_time = 5 # How many seconds to wait before trying connection again
+
 # Credentials for rti url access. Needs to be filled in on deployment
-rti_user = ''
-rti_pass = ''
+rti_user = 'koa'
+rti_pass = 'plate2'
+
 # RTI API parameters
 rti_ingesttype = 'lev1'
 rti_reingest = False
 rti_testonly = False
 rti_dev = True
+
+## QL Frame Parameters
+ql_method = 'median' # options are median, mean, or whitelight
+
+# Pixels to trim from each side of the frame
+DAR_left = 5
+DAR_right = 5
+DAR_bottom = 15
+DAR_top = 13
+
+# Factor by which the frame should be scaled. When set to 1, frames will be ~100
+# pixels tall, which can be an issue for systems that can't easily zoom in
+ql_scale = 10
+
+# Processes to clean-up
+extra_process = bokeh,FirefoxApp,geckodriver
+
+
+[RTI_LEVEL2]
+# Keck Deployment Parameters
+;rti_url = https://www2.keck.hawaii.edu/koa/koa_team/rti_status.php
+rti_url = http://vm-koarti.keck.hawaii.edu:55556/ingest_api
+rti_attempts = 3 # How many times should the pipeline retry connecting to RTI
+rti_retry_time = 5 # How many seconds to wait before trying connection again
+
+# Credentials for rti url access. Needs to be filled in on deployment
+rti_user = 'koa'
+rti_pass = 'plate2'
+
+rti_ingesttype = 'lev2'
+rti_reingest = False
+rti_testonly = False
+rti_dev = True
+
+## QL Frame Parameters
+ql_method = 'median' # options are median, mean, or whitelight
+
+# Pixels to trim from each side of the frame
+DAR_left = 5
+DAR_right = 5
+DAR_bottom = 15
+DAR_top = 13
+
+# Factor by which the frame should be scaled. When set to 1, frames will be ~100
+# pixels tall, which can be an issue for systems that can't easily zoom in
+ql_scale = 10
+
+# Processes to clean-up
+extra_process = bokeh,FirefoxApp,geckodriver

--- a/kcwidrp/core/notify_api.py
+++ b/kcwidrp/core/notify_api.py
@@ -16,19 +16,13 @@ def rti_config_data(config):
     return url, user, pw
 
 
-def send_api_complete(config, utdate, logger):
-
-    data = {
-        'instrument': 'KCWI',
-        'utdate': utdate,
-        'ingesttype': 'lev2'
-    }
+def send_data_api(data, config, logger):
 
     url, user, pw = rti_config_data(config)
 
     try:
         res = requests.get(url, params=data, auth=(user, pw))
-        logger.info(f"Sending Complete Status {res.request.url}")
+        logger.info(f"Sending {data} to {res.request.url}")
     except requests.exceptions.RequestException as e:
         logger.error(f"Error caught while posting to {url}:")
         logger.error(e)

--- a/kcwidrp/core/notify_complete.py
+++ b/kcwidrp/core/notify_complete.py
@@ -1,0 +1,32 @@
+import requests
+
+
+def rti_config_data(config):
+
+    url = config.rti_url
+    user = config.rti_user
+    pw = config.rti_pass,
+
+    return url, user, pw
+
+
+def send_api_complete(config, utdate, logger):
+
+    data = {
+        'instrument': 'KCWI',
+        'utdate': utdate,
+        'ingesttype': 'lev2'
+    }
+
+    url, user, pw = rti_config_data(config)
+
+    try:
+        res = requests.get(url, params=data, auth=(user, pw))
+        logger.info(f"Sending Complete Status {res.request.url}")
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error caught while posting to {url}:")
+        logger.error(e)
+        return None
+
+    return res
+

--- a/kcwidrp/core/notify_complete.py
+++ b/kcwidrp/core/notify_complete.py
@@ -7,6 +7,12 @@ def rti_config_data(config):
     user = config.rti_user
     pw = config.rti_pass,
 
+    if type(pw) == tuple:
+        try:
+            pw = pw[0]
+        except IndexError:
+            pw = ''
+
     return url, user, pw
 
 

--- a/kcwidrp/primitives/ExtractArcs.py
+++ b/kcwidrp/primitives/ExtractArcs.py
@@ -109,14 +109,27 @@ class ExtractArcs(BasePrimitive):
                 xv = []
                 yv = []
                 for i in range(sectors):
-                    mi = np.nanargmin(arc[50+i*div:50+(i+1)*div])
-                    mn = np.nanmin(arc[50+i*div:50+(i+1)*div])
+                    try:
+                        mi = np.nanargmin(arc[50+i*div:50+(i+1)*div])
+                    except ValueError:
+                        self.logger.warn("slice is all NaN,  indices")
+                        mi = 0
+
+                    try:
+                        mn = np.nanmin(arc[50 + i * div:50 + (i + 1) * div])
+                    except RuntimeWarning:
+                        self.logger.warn("slice is all NaN,  setting to 0")
+                        mn = 0
+
                     xv.append(mi+50+i*div)
                     yv.append(mn)
+
                 # fit minima to model background
                 res = np.polyfit(xv, yv, 3)
                 xp = np.arange(len(arc))
+
                 bkg = np.polyval(res, xp)   # resulting model
+
                 # plot if requested
                 if do_plot:
                     p = figure(title=self.action.args.plotlabel + "ARC # %d" %
@@ -135,6 +148,7 @@ class ExtractArcs(BasePrimitive):
                 arc -= bkg
                 # add to arcs list
                 arcs.append(arc)
+
         # Did we get the correct number of arcs?
         if len(arcs) == self.config.instrument.NBARS:
             self.logger.info("Extracted %d arcs" % len(arcs))

--- a/kcwidrp/primitives/MakeInvsens.py
+++ b/kcwidrp/primitives/MakeInvsens.py
@@ -78,6 +78,7 @@ class MakeInvsens(BasePrimitive):
 
         suffix = 'invsens'
         stdname = self.action.args.stdname
+        master_inter = (self.config.instrument.plot_level >= 2)
 
         # get size
         sz = self.action.args.ccddata.data.shape
@@ -271,7 +272,7 @@ class MakeInvsens(BasePrimitive):
         wlm0 = wgoo0
         wlm1 = wgoo1
         # interactively set wavelength limits
-        if self.config.instrument.plot_level >= 1:
+        if master_inter:
             yran = [np.min(obsspec), np.max(obsspec)]
             source = ColumnDataSource(data=dict(x=w, y=obsspec))
             done = False
@@ -314,7 +315,7 @@ class MakeInvsens(BasePrimitive):
             nwl_good = len(wl_good)
         # END: interactively set wavelength limits
         # Now interactively identify lines
-        if self.config.instrument.plot_level >= 1:
+        if master_inter:
             yran = [np.min(obsspec), np.max(obsspec)]
             # source = ColumnDataSource(data=dict(x=w, y=obsspec))
             done = False
@@ -419,7 +420,7 @@ class MakeInvsens(BasePrimitive):
         pcal = None
         prsd = None
         # interactively adjust fit
-        if self.config.instrument.plot_level >= 1:
+        if master_inter:
             done = False
             while not done:
                 yran = [np.min(100.*af/area), np.max(100.*af/area)]
@@ -445,7 +446,7 @@ class MakeInvsens(BasePrimitive):
                           line_color='black', line_dash='dashdot')
                 set_plot_lims(peff, xlim=[wall0, wall1], ylim=yran)
                 bokeh_plot(peff, self.context.bokeh_session)
-                if self.config.instrument.plot_level >= 1:
+                if master_inter:
                     input("Next? <cr>: ")
                 else:
                     time.sleep(2. * self.config.instrument.plot_pause)
@@ -466,7 +467,7 @@ class MakeInvsens(BasePrimitive):
                 pivs.line([wlm1, wlm1], yran, line_color='green')
                 set_plot_lims(pivs, xlim=[wall0, wall1], ylim=yran)
                 bokeh_plot(pivs, self.context.bokeh_session)
-                if self.config.instrument.plot_level >= 1:
+                if master_inter:
                     input("Next? <cr>: ")
                 else:
                     time.sleep(2. * self.config.instrument.plot_pause)
@@ -485,7 +486,7 @@ class MakeInvsens(BasePrimitive):
                 pcal.line([wlm1, wlm1], yran, line_color='green')
                 set_plot_lims(pcal, xlim=[wall0, wall1], ylim=yran)
                 bokeh_plot(pcal, self.context.bokeh_session)
-                if self.config.instrument.plot_level >= 1:
+                if master_inter:
                     input("Next? <cr>: ")
                 else:
                     time.sleep(2. * self.config.instrument.plot_pause)
@@ -515,7 +516,7 @@ class MakeInvsens(BasePrimitive):
                           line_color='black', line_dash='dashed')
                 set_plot_lims(prsd, xlim=[wall0, wall1], ylim=yran)
                 bokeh_plot(prsd, self.context.bokeh_session)
-                if self.config.instrument.plot_level >= 1:
+                if master_inter:
                     qstr = input("Current fit order = %d, "
                                  "New fit order? <int>, <cr> - done: " % ford)
                     if len(qstr) <= 0:

--- a/kcwidrp/primitives/MakeMasterDark.py
+++ b/kcwidrp/primitives/MakeMasterDark.py
@@ -20,11 +20,13 @@ class MakeMasterDark(BaseImg):
         """
         # get list of dark frames
         self.logger.info("Checking precondition for stack_darks")
-        self.combine_list = self.context.proctab.n_proctab(
+        self.combine_list = self.context.proctab.search_proctab(
             frame=self.action.args.ccddata, target_type='DARK',
             target_group=self.action.args.groupid)
+
         self.logger.info(f"pre condition got {len(self.combine_list)},"
                          f" expecting {self.action.args.min_files}")
+
         # do we meet the criterion?
         if len(self.combine_list) >= self.action.args.min_files:
             return True

--- a/kcwidrp/primitives/SendHTTP.py
+++ b/kcwidrp/primitives/SendHTTP.py
@@ -13,7 +13,7 @@ class SendHTTP(BasePrimitive):
     def __init__(self, action, context):
         BasePrimitive.__init__(self, action, context)
         self.logger = context.pipeline_logger
-    
+
     def _pre_condition(self):
         self.user = self.config.rti.rti_user
         self.pw = self.config.rti.rti_pass
@@ -28,7 +28,7 @@ class SendHTTP(BasePrimitive):
             self.logger.error(f"Encountered a file with no KOA ID: {self.action.args.name}")
             return self.action.args
         
-        data_directory = os.path.join(self.config.rti.cwd,
+        data_directory = os.path.join(self.config.instrument.cwd,
                                       self.config.rti.output_directory)
         
         self.logger.info(f"Alerting RTI that {strip_fname(self.action.args.name)} is ready for ingestion")
@@ -44,7 +44,6 @@ class SendHTTP(BasePrimitive):
             'testonly': self.config.rti.rti_testonly,
             'dev': self.config.rti.rti_dev
         }
-        
         attempts = 0
         limit = self.config.rti.rti_attempts
         while attempts < limit:

--- a/kcwidrp/primitives/SendHTTP.py
+++ b/kcwidrp/primitives/SendHTTP.py
@@ -28,7 +28,7 @@ class SendHTTP(BasePrimitive):
             self.logger.error(f"Encountered a file with no KOA ID: {self.action.args.name}")
             return self.action.args
         
-        data_directory = os.path.join(self.config.instrument.cwd,
+        data_directory = os.path.join(self.config.rti.cwd,
                                       self.config.rti.output_directory)
         
         self.logger.info(f"Alerting RTI that {strip_fname(self.action.args.name)} is ready for ingestion")

--- a/kcwidrp/primitives/SolveArcs.py
+++ b/kcwidrp/primitives/SolveArcs.py
@@ -13,6 +13,7 @@ from scipy.stats import sigmaclip
 from bokeh.plotting import figure
 from bokeh.models import Range1d, LinearAxis
 import time
+import math
 
 
 class SolveArcs(BasePrimitive):
@@ -245,6 +246,7 @@ class SolveArcs(BasePrimitive):
             self.logger.info("Fitting wavelength solution starting with %d "
                              "lines after rejecting %d lines" %
                              (len(arc_pix_dat), nrej))
+
             # Fit wavelengths
             # Get poly order
             if self.action.args.dichroic_fraction <= 0.6:
@@ -271,7 +273,8 @@ class SolveArcs(BasePrimitive):
             rej_rsd_flux = []   # rejected line fluxes
             # iteratively remove outliers
             it = 0
-            while max_resid > 2.5 * wsig and it < 25:
+            while (max_resid > 2.5 * wsig and it < 25 and
+                   not math.isclose(max_resid, 2.5 * wsig, abs_tol=0.01)):
                 arc_dat = []    # arc line pixel values
                 arc_fdat = []   # arc line flux data
                 at_dat = []     # atlas line wavelength values

--- a/kcwidrp/primitives/SolveArcs.py
+++ b/kcwidrp/primitives/SolveArcs.py
@@ -273,8 +273,10 @@ class SolveArcs(BasePrimitive):
             rej_rsd_flux = []   # rejected line fluxes
             # iteratively remove outliers
             it = 0
+
+            # avoid infinite loop due to floating point comparison w/isclose
             while (max_resid > 2.5 * wsig and it < 25 and
-                   not math.isclose(max_resid, 2.5 * wsig, abs_tol=0.01)):
+                   not math.isclose(max_resid, 2.5 * wsig, abs_tol=0.0001)):
                 arc_dat = []    # arc line pixel values
                 arc_fdat = []   # arc line flux data
                 at_dat = []     # atlas line wavelength values

--- a/kcwidrp/primitives/kcwi_file_primitives.py
+++ b/kcwidrp/primitives/kcwi_file_primitives.py
@@ -448,10 +448,6 @@ class ingest_file(BasePrimitive):
         return bsec, dsec, tsec, direc
 
     def _perform(self):
-        # if self.context.data_set is None:
-        #    self.context.data_set = DataSet(None, self.logger, self.config,
-        #    self.context.event_queue)
-        # self.context.data_set.append_item(self.action.args.name)
         self.logger.info(
             "------------------- Ingesting file %s -------------------" %
             self.action.args.name)
@@ -477,10 +473,17 @@ class ingest_file(BasePrimitive):
             self.logger.warn(f"Unknown IMTYPE {fname}")
             self.action.event._reccurent = False
 
-        if self.check_if_file_can_be_processed(imtype) is False:
-            # self.logger.warn("Object frame cannot be reduced. Rescheduling")
+        if not self.check_if_file_can_be_processed(imtype):
             self.action.new_event = None
+
+            # don't reschedule in group mode,  all files processed in order.
+            try:
+                self.action.event._recurrent = self.action.args.reschedule
+            except AttributeError:
+                pass
+
             return None
+
         else:
             self.action.event._recurrent = False
 
@@ -593,8 +596,6 @@ class ingest_file(BasePrimitive):
             else:
                 self.logger.warn(f"Cannot reduce {imtype} frame. Missing master bias. Rescheduling for later.")
                 return False
-
-
 
         return True
 

--- a/kcwidrp/scripts/kcwi_rti.py
+++ b/kcwidrp/scripts/kcwi_rti.py
@@ -22,6 +22,7 @@ import pkg_resources
 import types
 import psutil
 import getpass
+import pandas
 
 from kcwidrp.pipelines.keck_rti_pipeline import Keck_RTI_Pipeline
 from kcwidrp.core.kcwi_proctab import Proctab
@@ -88,77 +89,44 @@ def _parse_arguments(in_args: list) -> argparse.Namespace:
     return out_args
 
 
-def check_directory(directory):
-    if not os.path.isdir(directory):
-        os.makedirs(directory)
-        print("Directory %s has been created" % directory)
-
-
-def stop_processes(extra_process, logger):
-    current_user = getpass.getuser()
-
-    if not extra_process:
-        logger.info('No extra processes defined to stop.')
-        return
-
-    extra_process = extra_process.split(',')
-
-    for proc in psutil.process_iter():
-        pinfo = proc.as_dict(attrs=['name', 'username', 'pid', 'cmdline'])
-
-        if pinfo['username'] != current_user:
-            continue
-
-        for cmd in pinfo['cmdline']:
-            for process in extra_process:
-                if process in cmd:
-                    logger.info(f"Terminating process: {pinfo['cmdline']}, "
-                                f"pid: {pinfo['pid']}")
-                    p = psutil.Process(pinfo['pid'])
-                    p.terminate()
-
-
 def main():
 
-    def process_subset(in_subset):
-        for in_frame in in_subset.index:
-            arguments = Arguments(name=in_frame)
-            framework.append_event('next_file', arguments, recurrent=True)
-    
-    def process_list(in_list):
-        for in_frame in in_list:
-            arguments = Arguments(name=in_frame)
-            framework.append_event('next_file', arguments, recurrent=True)
+    args = _parse_arguments(sys.argv)
 
     def _on_exit(_, exit_status):
-        data_date = None
-        if rti_config.rti_ingesttype == 'lev2':
-            for direct in kcwi_config.cwd.split('/'):
-                try:
-                    data_date = int(direct)
-                    assert len(str(data_date)) == 8
-                except (ValueError, AssertionError):
-                    pass
 
-            if data_date:
-                result = send_api_complete(rti_config, data_date, framework.logger)
-                framework.logger.info(f"Complete status sent to koa_status table, "
-                                      f"with result {result}")
-            else:
-                framework.logger.error("Could not determine the date to send "
-                                       "the complete status to koa")
+        if rti_config.rti_ingesttype == 'lev2':
+            _send_complete()
 
         stop_processes(rti_config.extra_process, framework.logger)
 
         os._exit(exit_status)
 
-    args = _parse_arguments(sys.argv)
+    def _send_complete():
+        data_date = None
+        for direct in kcwi_config.cwd.split('/'):
+            try:
+                data_date = int(direct)
+                assert len(str(data_date)) == 8
+            except (ValueError, AssertionError):
+                pass
+
+        if not data_date:
+            framework.logger.error("Could not determine the date to send "
+                                   "the complete status to koa")
+            return
+
+        result = send_api_complete(rti_config, data_date, framework.logger)
+        framework.logger.info(f"Complete status sent to koa_status table, "
+                              f"with result {result}")
+
 
     # START HANDLING OF CONFIGURATION FILES ##########
     pkg = 'kcwidrp'
 
-    # check for the logs diretory
+    # check for the logs directory
     check_directory("logs")
+
     # check for the plots directory
     check_directory("plots")
 
@@ -211,8 +179,7 @@ def main():
 
     framework.context.pipeline_logger = getLogger(framework_logcfg_fullpath,
                                                   name="KCWI")
-    framework.logger = getLogger(framework_logcfg_fullpath,
-                                 name="DRPF")
+    framework.logger = getLogger(framework_logcfg_fullpath, name="DRPF")
 
     if args.infiles is not None:
         framework.config.file_type = args.infiles
@@ -235,8 +202,8 @@ def main():
             framework.config.instrument.LINELIST = args.atlas_line_list
 
     # start the bokeh server is requested by the configuration parameters
-    if framework.config.instrument.enable_bokeh is True:
-        if check_running_process(process='bokeh') is False:
+    if framework.config.instrument.enable_bokeh:
+        if not check_running_process(process='bokeh'):
             subprocess.Popen('bokeh serve', shell=True)
             # --session-ids=unsigned --session-token-expiration=86400',
             # shell=True)
@@ -260,7 +227,7 @@ def main():
     # the default ingestion action to no-event,
     # otherwise the system will automatically trigger the next_file event
     # which initiates the processing
-    if args.group_mode is True:
+    if args.group_mode:
         # set the default ingestion event to None
         framework.config.default_ingestion_event = "add_only"
 
@@ -297,40 +264,141 @@ def main():
         framework.ingest_data(args.dirname, None, args.monitor)
 
     # implement the group mode
-    if args.group_mode is True:
-        data_set = framework.context.data_set
-
-        # remove focus images and ccd clearing images from the dataset
-        focus_frames = data_set.data_table[data_set.data_table.OBJECT ==
-                                           "focus"].index
-        ccdclear_frames = data_set.data_table[data_set.data_table.OBJECT ==
-                                              "Clearing ccd"].index
-        data_set.data_table.drop(focus_frames, inplace=True)
-        data_set.data_table.drop(ccdclear_frames, inplace=True)
-
-        # processing
-        imtypes = ['BIAS', 'CONTBARS', 'ARCLAMP', 'FLATLAMP', 'DOMEFLAT', 'TWIFLAT', 'OBJECT']
-
-        for imtype in imtypes:
-            subset = data_set.data_table[
-                    framework.context.data_set.data_table.IMTYPE == imtype]
-
-            if 'OBJECT' in imtype: # Ensure that standards are processed first
-                object_order = []
-                standard_order = []
-                for frame in subset.index:
-                    if is_file_kcwi_std(frame, logger=framework.context.logger):
-                        standard_order.append(frame)
-                    else:
-                        object_order.append(frame)
-                order = standard_order + object_order # Standards first
-                process_list(order)
-            else:
-                process_subset(subset)
+    if args.group_mode:
+        process_group_mode(framework, args)
 
     framework.on_exit = types.MethodType(_on_exit, framework)
     framework.start(args.queue_manager_only, args.ingest_data_only,
                     args.wait_for_event, args.continuous)
+
+
+def check_directory(directory):
+    if not os.path.isdir(directory):
+        os.makedirs(directory)
+        print("Directory %s has been created" % directory)
+
+
+def stop_processes(extra_process, logger):
+    current_user = getpass.getuser()
+
+    if not extra_process:
+        logger.info('No extra processes defined to stop.')
+        return
+
+    extra_process = extra_process.split(',')
+
+    for proc in psutil.process_iter():
+        pinfo = proc.as_dict(attrs=['name', 'username', 'pid', 'cmdline'])
+
+        if pinfo['username'] != current_user:
+            continue
+
+        for cmd in pinfo['cmdline']:
+            for process in extra_process:
+                if process in cmd:
+                    logger.info(f"Terminating process: {pinfo['cmdline']}, "
+                                f"pid: {pinfo['pid']}")
+                    p = psutil.Process(pinfo['pid'])
+                    p.terminate()
+
+
+def process_group_mode(framework, args):
+    """
+    Group the files by imagetype and binning.  Then process in sets and in the
+    sequence required to reduce the next set.  The order is defined by imtypes
+    list,  and the processing is done one set at a time.  Each set is processed
+    together in parallel and then returns before starting the next set.
+    """
+
+    def _on_grp_complete(_, exit_status):
+        return
+
+    def add_grp(grp_list, resched):
+        for in_frame in grp_list:
+            framework.logger.info(f"File to process: {in_frame}")
+            arguments = Arguments(name=in_frame, reschedule=resched)
+            framework.append_event('next_file', arguments, recurrent=True)
+
+    def process_grp(grp_list, resched):
+        add_grp(grp_list, resched)
+
+        framework.on_exit = types.MethodType(_on_grp_complete, framework)
+        framework.start(args.queue_manager_only, args.ingest_data_only,
+                        args.wait_for_event, args.continuous)
+
+    def process_by_expt(exptimes, imtype, binning):
+        for expt in exptimes:
+            subset = data_set.data_table[
+                (framework.context.data_set.data_table.IMTYPE == imtype)
+                & (framework.context.data_set.data_table.BINNING.str.contains(binning))
+                & (framework.context.data_set.data_table.TTIME == expt)]
+
+            framework.logger.info(f"Processing type={imtype}, binning={binning}"
+                                  f", exptime={expt}")
+
+            process_grp(subset.index, False)
+
+    def divide_and_process():
+        if imtype == 'BIAS':
+            subset = data_set.data_table[
+                (framework.context.data_set.data_table.IMTYPE == imtype) &
+                (framework.context.data_set.data_table.BINNING.str.contains(binning))
+                & (framework.context.data_set.data_table.TTIME == 0.0)]
+        else:
+            subset = data_set.data_table[
+                (framework.context.data_set.data_table.IMTYPE == imtype) &
+                (framework.context.data_set.data_table.BINNING.str.contains(binning))]
+
+        if len(subset) == 0:
+            return
+
+        framework.logger.info(f"Processing type={imtype}, binning={binning}")
+
+        if 'OBJECT' in imtype:  # Ensure that standards are processed first
+            for frame in subset.index:
+                # this only checks for standards with same name as KCWI standards
+                if is_file_kcwi_std(frame, logger=framework.context.logger):
+                    standard.append(frame)
+                else:
+                    science.append(frame)
+
+        elif 'DARK' in imtype:
+            exptimes = set()
+            for expt in subset.TTIME:
+                exptimes.add(expt)
+            process_by_expt(exptimes)
+
+        else:
+            process_grp(subset.index, False)
+
+    data_set = framework.context.data_set
+
+    # remove focus images and ccd clearing images from the dataset
+    try:
+        focus_frames = data_set.data_table[data_set.data_table.OBJECT == "focus"].index
+    except AttributeError:
+        framework.logger.warn("Empty dataset,  exiting group mode.")
+        return
+
+    ccdclear_frames = data_set.data_table[data_set.data_table.OBJECT == "Clearing ccd"].index
+    data_set.data_table.drop(focus_frames, inplace=True)
+    data_set.data_table.drop(ccdclear_frames, inplace=True)
+
+    # list order is important to process the calibrations in the correct order.
+    imtypes = ['BIAS', 'DARK', 'CONTBARS', 'ARCLAMP', 'FLATLAMP',
+               'DOMEFLAT', 'TWIFLAT', 'OBJECT']
+
+    allowed_binning = ('1,1', '2,2')
+
+    science = []
+    standard = []
+
+    for imtype in imtypes:
+        for binning in allowed_binning:
+            divide_and_process()
+
+    process_grp(standard, False)
+    add_grp(science, False)
 
 
 if __name__ == "__main__":

--- a/kcwidrp/scripts/reduce_kcwi.py
+++ b/kcwidrp/scripts/reduce_kcwi.py
@@ -248,7 +248,7 @@ def main():
         data_set.data_table.drop(ccdclear_frames, inplace=True)
 
         # processing
-        imtypes = ['BIAS', 'CONTBARS', 'ARCLAMP', 'FLATLAMP', 'DOMEFLAT', 'TWIFLAT', 'OBJECT']
+        imtypes = ['BIAS', 'DARK', 'CONTBARS', 'ARCLAMP', 'FLATLAMP', 'DOMEFLAT', 'TWIFLAT', 'OBJECT']
 
         for imtype in imtypes:
             subset = data_set.data_table[


### PR DESCRIPTION
Update to group mode for RTI.  The original grouping was entering an infinite loop of rescheduling when waiting on missing calibrations.   Group mode now does not reschedule,  but process files by type,  binning,  and exposure time (when relevant).  The groups are processed sequentially with each group of files processed in parallel.  

There were a few small changes to error handling of the primitives.  One notable exception is from numpy nan methods,  there is currently no handling of the exceptions raised by these methods.  Added warnings in ExtractArcs.  It might be worth adding these throughout the pipeline,  I noticed several 'nanmin' without a catch of the exception it raises.