### PR TITLE
Rti fix dark processing

### DIFF
--- a/kcwidrp/core/bspline/Bspline.py
+++ b/kcwidrp/core/bspline/Bspline.py
@@ -430,17 +430,27 @@ class Bspline(object):
         nbkpt = self.mask.sum()
         if nbkpt <= 2*self.nord:
             return -2
-        hmm = err[np.unique(err/self.npoly)]/self.npoly
+
+        # TODO I am not sure of this one
+        # hmm = err[np.unique(err / self.npoly)] / self.npoly
+        try:
+            hmm = err[np.unique(err/self.npoly)]/self.npoly
+        except IndexError:
+            hmm = np.unique(err)/self.npoly
+
         n = nbkpt - self.nord
         if np.any(hmm >= n):
             return -2
         test = np.zeros(nbkpt, dtype='bool')
-        for jj in range(-np.ceil(self.nord/2.0), int(self.nord/2.0)):
+
+        for jj in range(int(-np.ceil(self.nord/2.0)), int(self.nord/2.0)):
             foo = np.where((hmm+jj) > 0, hmm+jj, np.zeros(hmm.shape,
                                                           dtype=hmm.dtype))
             inside = np.where((foo+self.nord) < n-1, foo+self.nord,
                               np.zeros(hmm.shape, dtype=hmm.dtype)+n-1)
+
             test[inside] = True
+
         if test.any():
             reality = self.mask[test]
             if self.mask[reality].any():
@@ -591,6 +601,10 @@ def cholesky_band(ndl, mininf=0.0):
         # Figure out where the error is.
         #
         lower = ndl.copy()
+
+        # correct the dimension for setting equal to ll below
+        lower = lower[:, 0:n]
+
         kn = bw - 1
         spot = np.arange(kn, dtype='i4') + 1
         for j in range(n):

--- a/kcwidrp/core/bspline/Bspline.py
+++ b/kcwidrp/core/bspline/Bspline.py
@@ -431,8 +431,6 @@ class Bspline(object):
         if nbkpt <= 2*self.nord:
             return -2
 
-        # TODO I am not sure of this one
-        # hmm = err[np.unique(err / self.npoly)] / self.npoly
         try:
             hmm = err[np.unique(err/self.npoly)]/self.npoly
         except IndexError:

--- a/kcwidrp/primitives/ExtractArcs.py
+++ b/kcwidrp/primitives/ExtractArcs.py
@@ -32,7 +32,6 @@ class ExtractArcs(BasePrimitive):
         self.logger.info("%d continuum bars frames found" %
                          len(contbars_in_proctable))
 
-        # this just reads the first CONTBAR filename found
         if len(contbars_in_proctable) > 0:
             self.action.args.original_filename = strip_fname(
                 contbars_in_proctable['filename'][0])+ "_trace.fits"

--- a/kcwidrp/primitives/ExtractArcs.py
+++ b/kcwidrp/primitives/ExtractArcs.py
@@ -31,6 +31,8 @@ class ExtractArcs(BasePrimitive):
             nearest=True)
         self.logger.info("%d continuum bars frames found" %
                          len(contbars_in_proctable))
+
+        # this just reads the first CONTBAR filename found
         if len(contbars_in_proctable) > 0:
             self.action.args.original_filename = strip_fname(
                 contbars_in_proctable['filename'][0])+ "_trace.fits"
@@ -49,18 +51,15 @@ class ExtractArcs(BasePrimitive):
         # All is ready
         original_filename = self.action.args.original_filename
         self.logger.info("Trace table found: %s" % original_filename)
-        # trace = read_table(tab=tab, indir='redux', suffix='trace')
-        # Find  and read control points from continuum bars
-        if hasattr(self.context, 'trace'):
-            trace = self.context.trace
-        else:
-            trace = read_table(
-                input_dir=os.path.join(self.config.instrument.cwd,
-                                       self.config.instrument.output_directory),
-                file_name=original_filename)
-            self.context.trace = {}
-            for key in trace.meta.keys():
-                self.context.trace[key] = trace.meta[key]
+        # Read the trace table produced by the CONTBAR files,
+        # there may be more than one.
+        trace = read_table(
+            input_dir=os.path.join(self.config.instrument.cwd,
+                                   self.config.instrument.output_directory),
+            file_name=original_filename)
+        self.context.trace = {}
+        for key in trace.meta.keys():
+            self.context.trace[key] = trace.meta[key]
         middle_row = self.context.trace['MIDROW']
         window = self.context.trace['WINDOW']
         self.action.args.reference_bar_separation = self.context.trace[

--- a/kcwidrp/primitives/FindBars.py
+++ b/kcwidrp/primitives/FindBars.py
@@ -144,7 +144,7 @@ class FindBars(BasePrimitive):
         self.action.args.contbar_image_number = \
             self.action.args.ccddata.header['FRAMENO']
         self.action.args.contbar_image = \
-            self.action.args.ccddata.header['OFNAME']
+            self.action.args.ccddata.header['KOAID']
 
         log_string = FindBars.__module__
         self.action.args.ccddata.header['HISTORY'] = log_string

--- a/kcwidrp/primitives/FindBars.py
+++ b/kcwidrp/primitives/FindBars.py
@@ -143,8 +143,8 @@ class FindBars(BasePrimitive):
         # store image info
         self.action.args.contbar_image_number = \
             self.action.args.ccddata.header['FRAMENO']
-        self.action.args.contbar_image = \
-            self.action.args.ccddata.header['KOAID']
+
+        self.action.args.contbar_image = self.action.args.name
 
         log_string = FindBars.__module__
         self.action.args.ccddata.header['HISTORY'] = log_string

--- a/kcwidrp/primitives/MakeMasterDark.py
+++ b/kcwidrp/primitives/MakeMasterDark.py
@@ -41,14 +41,23 @@ class MakeMasterDark(BaseImg):
         method = 'average'
         suffix = args.new_type.lower()
 
+        # read from and write to the output directory
+        output_dir = os.path.join(self.config.instrument.cwd,
+                                  self.config.instrument.output_directory)
+
         combine_list = list(self.combine_list['filename'])
+
         # get master dark output name
-        mdname = strip_fname(combine_list[0]) + '_' + suffix + '.fits'
+        mdname = strip_fname(self.action.args.name) + '_' + suffix + '.fits'
+
         stack = []
         stackf = []
+
         for dark in combine_list:
+
             # get dark intensity (int) image file name in redux directory
-            stackf.append(dark.split('.fits')[0] + '_int.fits')
+            stackf.append(output_dir + "/" + strip_fname(dark) + '_int.fits')
+
             darkfn = os.path.join(args.in_directory, stackf[-1])
             # using [0] gets just the image data
             stack.append(kcwi_fits_reader(darkfn)[0])
@@ -69,7 +78,8 @@ class MakeMasterDark(BaseImg):
         self.logger.info(log_string)
 
         kcwi_fits_writer(stacked, output_file=mdname,
-                         output_dir=self.config.instrument.output_directory)
+                         output_dir=output_dir)
+
         self.context.proctab.update_proctab(frame=stacked, suffix=suffix,
                                             newtype=args.new_type,
                                             filename=self.action.args.name)

--- a/kcwidrp/primitives/TraceBars.py
+++ b/kcwidrp/primitives/TraceBars.py
@@ -160,7 +160,11 @@ class TraceBars(BasePrimitive):
                                       self.action.args.contbar_image_number,
                                       "Cont. bars image number"),
                                   'CBARSFL': (self.action.args.contbar_image,
-                                              "Cont. bars image")})
+                                              "Cont. bars image"),
+                                  'STATEID': (self.action.args.ccddata.header["STATEID"],
+                                              "CONTBAR STATEID")
+                                  }
+                        )
 
             if self.config.instrument.saveintims:
                 from kcwidrp.primitives.kcwi_file_primitives import \

--- a/kcwidrp/primitives/TraceBars.py
+++ b/kcwidrp/primitives/TraceBars.py
@@ -139,6 +139,12 @@ class TraceBars(BasePrimitive):
             self.context.trace = trace
             ofname = strip_fname(self.action.args.contbar_image) + \
                 "_trace.fits"
+
+            if 'STATEID' in self.action.args.ccddata.header:
+                stateid = self.action.args.ccddata.header["STATEID"]
+            else:
+                stateid = 0
+
             write_table(table=[src, dst, barid, slid],
                         names=('src', 'dst', 'barid', 'slid'),
                         output_dir=os.path.join(
@@ -161,8 +167,7 @@ class TraceBars(BasePrimitive):
                                       "Cont. bars image number"),
                                   'CBARSFL': (self.action.args.contbar_image,
                                               "Cont. bars image"),
-                                  'STATEID': (self.action.args.ccddata.header["STATEID"],
-                                              "CONTBAR STATEID")
+                                  'STATEID': (stateid, "CONTBAR STATEID")
                                   }
                         )
 

--- a/kcwidrp/scripts/kcwi_rti.py
+++ b/kcwidrp/scripts/kcwi_rti.py
@@ -335,7 +335,7 @@ def process_group_mode(framework, args):
         framework.start(args.queue_manager_only, args.ingest_data_only,
                         args.wait_for_event, args.continuous)
 
-    def process_by_expt(exptimes, imtype, binning):
+    def process_by_expt(exptimes):
         for expt in exptimes:
             subset = data_set.data_table[
                 (framework.context.data_set.data_table.IMTYPE == imtype)


### PR DESCRIPTION
Found error in reducing Arcs when there was more than
one configuration with >1 _trace file created.

Changes:  

ExtractArcs.py -- read the trace instead of using the last one read.  Some nights contain multiple traces, and it relies on an order of reduction if using the last trace created.  Changed from reading the one in 'context' to explicitly read the matching trace.

FindBars.py -- Changed name of trace file to be the name of the contbar calibration file +_trace. 

TraceBars.py -- added stateid to the header as a secondary method to match the trace.

MakeMasterDark.py -- changed location to redux dir for making the master flat,  originally looking in lev0 for _int files.  Also updated proctable to have the correct name of the master flat created.

---
Encountered errors in the masking routines:

bspline/Bspline.py

ran into index errors in mask points.  Added an exception in the case where the index used is actually an array.  

Found an issue with the array dimensions in the except LinAlgError route.  The dimensions did not match the equality set further on for ll[:, 0:n] = lower.


