### PR TITLE
Cosmetic removal of references to variance

### DIFF
--- a/kcwidrp/primitives/CreateUncertaintyImage.py
+++ b/kcwidrp/primitives/CreateUncertaintyImage.py
@@ -20,7 +20,7 @@ class CreateUncertaintyImage(BasePrimitive):
         key = 'UNCSTD'
         keycom = 'stddev uncertainty created?'
 
-        self.logger.info("Create uncertainty image")
+        self.logger.info("Create StdDev uncertainty image")
         # start with Poisson noise
         self.action.args.ccddata.uncertainty = StdDevUncertainty(
             np.sqrt(np.abs(self.action.args.ccddata.data)), copy=True)
@@ -51,7 +51,7 @@ class CreateUncertaintyImage(BasePrimitive):
         if self.action.args.ccddata.mask is None:
             self.action.args.ccddata.mask = np.zeros(
                 self.action.args.ccddata.data.shape, dtype=np.uint8)
-        # document variance image creation
+        # document StdDev image creation
         self.action.args.ccddata.header[key] = (True, keycom)
 
         log_string = CreateUncertaintyImage.__module__

--- a/kcwidrp/primitives/FluxCalibrate.py
+++ b/kcwidrp/primitives/FluxCalibrate.py
@@ -25,9 +25,9 @@ class FluxCalibrate(BasePrimitive):
         """
         self.logger.info("Checking precondition for FluxCalibrate")
         target_type = 'INVSENS'
-        tab = self.context.proctab.search_proctab(frame=self.action.args.ccddata,
-                                             target_type=target_type,
-                                             nearest=True)
+        tab = self.context.proctab.search_proctab(
+            frame=self.action.args.ccddata, target_type=target_type,
+            nearest=True)
         self.logger.info("pre condition got %d invsens files, expected >= 1"
                          % len(tab))
         if len(tab) <= 0:
@@ -46,9 +46,9 @@ class FluxCalibrate(BasePrimitive):
         sky = None
 
         self.logger.info("Calibrating object flux")
-        tab = self.context.proctab.search_proctab(frame=self.action.args.ccddata,
-                                             target_type=target_type,
-                                             nearest=True)
+        tab = self.context.proctab.search_proctab(
+            frame=self.action.args.ccddata, target_type=target_type,
+            nearest=True)
         self.logger.info("%d invsens files found" % len(tab))
 
         if self.action.args.invsname is not None:
@@ -96,6 +96,7 @@ class FluxCalibrate(BasePrimitive):
             for isl in range(sz[2]):
                 for ix in range(sz[1]):
                     self.action.args.ccddata.data[:, ix, isl] *= mscal
+                    # calibrate StdDev uncertainty
                     self.action.args.ccddata.uncertainty.array[:, ix, isl] *= \
                         mscal
 


### PR DESCRIPTION
Cosmetic removal of references to variance in CreateUncertaintyImage.py, FluxCalibrate.py, and MakeCube.py and some
minor code tidying.  Looked through all references to 'uncertainty' in kcwidrp/primitives and attempted to make the use
of stddev for uncertainty unambiguous.