### PR TITLE
Fix broken call to get_master_name in MakeMasterObject

### DIFF
--- a/kcwidrp/primitives/MakeMasterContbars.py
+++ b/kcwidrp/primitives/MakeMasterContbars.py
@@ -62,7 +62,7 @@ class MakeMasterContbars(BaseImg):
             stack = []
             stackf = []
             for cbs in combine_list:
-                # get arc intensity (int) image file name in redux directory
+                # get cbars intensity (int) image file name in redux directory
                 stackf.append(strip_fname(cbs) + '_int.fits')
                 cbsfn = os.path.join(self.config.instrument.cwd, self.config.instrument.output_directory, stackf[-1])
                 # using [0] gets just the image data
@@ -86,7 +86,7 @@ class MakeMasterContbars(BaseImg):
             stacked.header['HISTORY'] = log_string
             self.action.args.ccddata = stacked
 
-            # get master arc output name
+            # get master cbars output name
             mcbars_name = strip_fname(combine_list[0]) + '_' + suffix + '.fits'
 
             kcwi_fits_writer(stacked, output_file=mcbars_name,

--- a/kcwidrp/primitives/MakeMasterObject.py
+++ b/kcwidrp/primitives/MakeMasterObject.py
@@ -101,7 +101,7 @@ class MakeMasterObject(BaseImg):
                                                          "stack input file")
             stacked.header['HISTORY'] = log_string
             self.action.args.ccddata = stacked
-            mobj_name = get_master_name(combine_list, "mobj")
+            mobj_name = strip_fname(combine_list[0]) + '_' + suffix + '.fits'
             kcwi_fits_writer(stacked, output_file=mobj_name,
                              output_dir=self.config.instrument.output_directory)
             self.context.proctab.update_proctab(frame=stacked, suffix=suffix,
@@ -110,7 +110,7 @@ class MakeMasterObject(BaseImg):
             # self.action.args.name = mobj_name
             # self.action.args.name = stacked.header['OFNAME']
         else:
-            mobj_name = get_master_name(combine_list, "mobj")
+            mobj_name = strip_fname(combine_list[0]) + '_' + suffix + '.fits'
             self.action.args.ccddata.header['IMTYPE'] = args.new_type
             self.action.args.ccddata.header['HISTORY'] = log_string
             kcwi_fits_writer(self.action.args.ccddata, output_file=mobj_name,


### PR DESCRIPTION
Reduction dies when trying to make a master object because the call to get_master_name requires table entries from the proctab and they only contain a list of filenames.  This PR will fix this.

Also updated comments in MakeMasterContbars that refer to "arc" when they should refer to "cbars".