### PR TITLE
no longer check groupid when gathering biases

### DIFF
--- a/kcwidrp/core/kcwi_proctab.py
+++ b/kcwidrp/core/kcwi_proctab.py
@@ -158,10 +158,6 @@ class Proctab:
                 self.log.info('Looking for frames with CCDCFG = %s' %
                               frame.header['CCDCFG'])
                 tab = tab[(tab['DID'] == int(frame.header['CCDCFG']))]
-                if target_group is not None:
-                    self.log.info('Looking for frames with GRPID = %s' %
-                                  target_group)
-                    tab = tab[(tab['GRPID'] == target_group)]
             # raw DARKS must have the same CCDCFG and TTIME
             elif target_type == 'DARK':
                 self.log.info('Looking for frames with CCDCFG = %s and '


### PR DESCRIPTION
In the rare case where biases are not all collected at the same time (which happened a week or two ago), the pipeline won't stack frames with matching ccd configurations. This PR removes a check for the groupid (which includes all configurable elements, not just the detector). Fixes #180 